### PR TITLE
Ensure default UI actions for Input System

### DIFF
--- a/Assets/Scripts/UI/InputModuleBootstrap.cs
+++ b/Assets/Scripts/UI/InputModuleBootstrap.cs
@@ -178,17 +178,20 @@ namespace RogueLike2D.UI
                 uim = es.gameObject.AddComponent<InputSystemUIInputModule>();
                 Debug.Log("[InputModuleBootstrap] Added InputSystemUIInputModule (New only)");
             }
-            // Warn if no actions asset is assigned; UI navigation may not work without it.
+            // If no actions asset is assigned, wire up the module with the built-in default
+            // so basic UI input (mouse, keyboard, gamepad) will work out of the box.
             try
             {
                 if (uim.actionsAsset == null)
                 {
-                    Debug.LogWarning("[InputModuleBootstrap] InputSystemUIInputModule has no actionsAsset assigned. Assign a UI actions asset in the EventSystem or via code.");
+                    // Load the default UI actions provided by the Input System package.
+                    uim.actionsAsset = InputSystemUIInputModule.LoadDefaultActions();
+                    Debug.Log("[InputModuleBootstrap] Assigned default UI actions asset to InputSystemUIInputModule");
                 }
             }
             catch (Exception ex)
             {
-                Debug.LogWarning($"[InputModuleBootstrap] Could not check actionsAsset: {ex}");
+                Debug.LogWarning($"[InputModuleBootstrap] Could not assign default actions asset: {ex}");
             }
 #else
             // Legacy or Both: ensure StandaloneInputModule is present for maximum compatibility.

--- a/Assets/Tests/EditMode/InputModuleBootstrapTests.cs
+++ b/Assets/Tests/EditMode/InputModuleBootstrapTests.cs
@@ -1,0 +1,30 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.EventSystems;
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+using UnityEngine.InputSystem.UI;
+#endif
+using RogueLike2D.UI;
+
+public class InputModuleBootstrapTests
+{
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+    [Test]
+    public void EnsureCorrectInputModule_AssignsDefaultActions()
+    {
+        // Create a bare EventSystem with no input modules attached.
+        var go = new GameObject("EventSystem", typeof(EventSystem));
+        var es = go.GetComponent<EventSystem>();
+
+        // Invoke the bootstrap to configure the proper input module.
+        InputModuleBootstrap.EnsureCorrectInputModule(es, "unit-test");
+
+        // The new Input System module should be added automatically.
+        var uim = es.GetComponent<InputSystemUIInputModule>();
+        Assert.IsNotNull(uim, "InputSystemUIInputModule should be present");
+
+        // The helper should assign a default actions asset so the UI can process input.
+        Assert.IsNotNull(uim.actionsAsset, "Expected a default actions asset to be assigned");
+    }
+#endif
+}

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Troubleshooting: UI input freezes or Exit button does nothing
 - Cause: The scene uses the legacy StandaloneInputModule while Project Settings > Player > Active Input Handling is set to "Input System Package (New)".
 - Fix applied by this repo:
   - Assets/Editor/EnsureInputSettings.cs automatically sets Active Input Handling to "Both" when the Editor opens. This makes the legacy StandaloneInputModule work and unfreezes the UI.
-  - At runtime, Assets/Scripts/UI/InputModuleBootstrap.cs ensures the correct EventSystem input module based on active input handling (adds InputSystemUIInputModule when only the new Input System is enabled; otherwise ensures StandaloneInputModule).
+  - At runtime, Assets/Scripts/UI/InputModuleBootstrap.cs ensures the correct EventSystem input module based on active input handling (adds InputSystemUIInputModule when only the new Input System is enabled; otherwise ensures StandaloneInputModule). If the new Input System module has no actions asset assigned, a default set is now provided so the UI can respond to input immediately.
   - You can also run it manually via menu: Tools > Roguelike2D > Fix Input Handling (Set to Both).
 - If you still see issues:
   - Ensure your scene has an EventSystem GameObject with a StandaloneInputModule component (or migrate to InputSystemUIInputModule and provide a UI actions asset).
@@ -82,5 +82,5 @@ CI/command line builds (no CLI override for Active Input Handling)
 - Windows quick build: run Tools\build_windows.bat. It invokes RogueLike2D.Editor.BuildScript.PerformWindowsBuild and writes build_log.txt to the repo root.
 - This repo includes a pre-build guard script (Assets/Editor/InputHandlingGuard.cs) that warns if the setting and your runtime UI path are likely mismatched. To make it fail the build on mismatch, add the scripting define symbol ROGUELIKE2D_FAIL_ON_INPUT_MISMATCH in Project Settings > Player > Other Settings > Scripting Define Symbols for your target.
 - Runtime EventSystem module selection:
-  - If ONLY the new Input System is enabled, use InputSystemUIInputModule. The included InputModuleBootstrap ensures this automatically at runtime.
+  - If ONLY the new Input System is enabled, use InputSystemUIInputModule. The included InputModuleBootstrap ensures this automatically at runtime and supplies a default actions asset if none is configured.
   - Otherwise (Both or Old), StandaloneInputModule will be ensured.


### PR DESCRIPTION
## Summary
- Auto-assign default UI actions asset to InputSystemUIInputModule when no actions are configured
- Document default action assignment in runtime input module selection guidance
- Test that InputModuleBootstrap supplies default actions under Input System only mode

## Testing
- `bash Tools/build_windows.bat` *(fails: `@echo: command not found`)*
- `unity -runTests -projectPath . -testPlatform editmode` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68c19d940a10832d88a33c9881760177