### PR TITLE
fix: update input system default actions call

### DIFF
--- a/Assets/Scripts/UI/InputModuleBootstrap.cs
+++ b/Assets/Scripts/UI/InputModuleBootstrap.cs
@@ -184,8 +184,10 @@ namespace RogueLike2D.UI
             {
                 if (uim.actionsAsset == null)
                 {
-                    // Load the default UI actions provided by the Input System package.
-                    uim.actionsAsset = InputSystemUIInputModule.LoadDefaultActions();
+                    // Create the default UI actions asset (covers basic mouse, keyboard, gamepad input).
+                    // The previous API "LoadDefaultActions" was removed in newer Input System versions,
+                    // so we now generate the asset at runtime using the provided helper.
+                    uim.actionsAsset = InputSystemUIInputModule.CreateDefaultActions();
                     Debug.Log("[InputModuleBootstrap] Assigned default UI actions asset to InputSystemUIInputModule");
                 }
             }

--- a/Assets/Tests/EditMode/InputModuleBootstrapTests.cs
+++ b/Assets/Tests/EditMode/InputModuleBootstrapTests.cs
@@ -24,6 +24,7 @@ public class InputModuleBootstrapTests
         Assert.IsNotNull(uim, "InputSystemUIInputModule should be present");
 
         // The helper should assign a default actions asset so the UI can process input.
+        // Internally this uses InputSystemUIInputModule.CreateDefaultActions().
         Assert.IsNotNull(uim.actionsAsset, "Expected a default actions asset to be assigned");
     }
 #endif


### PR DESCRIPTION
## Summary
- replace removed `LoadDefaultActions` with `CreateDefaultActions` in bootstrap
- note new helper in unit test comments

## Testing
- `./Tools/build_windows.bat` *(fails: command not found because Windows-specific batch script)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a7f199f4832d8dea265d1b891491