### PR TITLE
Ensure startup log marker in file logger

### DIFF
--- a/Assets/Scripts/Core/FileLogger.cs
+++ b/Assets/Scripts/Core/FileLogger.cs
@@ -10,6 +10,7 @@ namespace RogueLike2D.Core
     public static class FileLogger
     {
         private static readonly object _lock = new object();
+        private const string StartupMarkerPhrase = "Execution has entered the app";
         private static StreamWriter _writer;
         private static string _logDir;
         private static string _logFilePath;
@@ -84,26 +85,32 @@ namespace RogueLike2D.Core
                 Application.quitting += OnQuitting;
 
                 WriteSessionHeader();
-
-                // Best-effort: write a startup marker directly to the file to make it obvious that the app attempted to start.
-                try
-                {
-                    lock (_lock)
-                    {
-                        if (_writer != null)
-                        {
-                            _writer.WriteLine($"[FileLogger] Startup logged at {DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}");
-                            _writer.Flush();
-                        }
-                    }
-                }
-                catch { /* ignore */ }
+                WriteStartupMarker();
 
                 Debug.Log($"[FileLogger] Initialized. Writing to {_logFilePath}");
             }
             catch (Exception ex)
             {
                 Debug.LogError($"[FileLogger] Failed to initialize: {ex}");
+            }
+        }
+
+        private static void WriteStartupMarker()
+        {
+            try
+            {
+                lock (_lock)
+                {
+                    if (_writer == null) return;
+
+                    string timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
+                    _writer.WriteLine($"[STARTUP][{timestamp}] {StartupMarkerPhrase}. Log file: {_logFilePath}");
+                    _writer.Flush();
+                }
+            }
+            catch (Exception markerEx)
+            {
+                Debug.LogWarning($"[FileLogger] Failed to write startup marker: {markerEx}");
             }
         }
 

--- a/Assets/Tests/EditMode/FileLoggerTests.cs
+++ b/Assets/Tests/EditMode/FileLoggerTests.cs
@@ -16,5 +16,6 @@ public class FileLoggerTests
 
         string contents = File.ReadAllText(path);
         StringAssert.Contains("BASELINE", contents, "Expected baseline marker not found in log file.");
+        StringAssert.Contains("Execution has entered the app", contents, "Expected startup marker not found in log file.");
     }
 }


### PR DESCRIPTION
## Summary
- ensure the file logger writes an explicit startup marker when initialized so players can see when execution entered the app
- include the log file path in the startup marker for clarity and keep the write guarded by the existing lock
- expand the FileLogger edit-mode test to assert the startup marker text is present in the generated log file

## Testing
- not run (Unity build tooling unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68caab21f8f0832d82d20b5e413133da